### PR TITLE
Feature/update simple connection factory

### DIFF
--- a/RabbitMQSimpleProducer/Producer.cs
+++ b/RabbitMQSimpleProducer/Producer.cs
@@ -12,11 +12,13 @@ namespace RabbitMQSimpleProducer
     {
         private IModel _channel;
         private readonly ConnectionSetting _connectionSetting;
+        private readonly ChannelFactory _channelFactory;
 
         public Producer(ConnectionSetting connectionSetting)
         {
             _connectionSetting = connectionSetting;
-            _channel = ChannelFactory.Create(_connectionSetting, automaticRecoveryEnabled: true, requestedHeartbeat: 60);
+            _channelFactory = new ChannelFactory(connectionSetting);
+            _channel = _channelFactory.Create(automaticRecoveryEnabled: true, requestedHeartbeat: 60);
         }
 
         /// <summary>
@@ -30,7 +32,7 @@ namespace RabbitMQSimpleProducer
             ProcessHandler.Retry(() =>
             {
                 if (_channel == null || _channel.IsClosed)
-                    _channel = ChannelFactory.Create(_connectionSetting, automaticRecoveryEnabled: true, requestedHeartbeat: 60);
+                    _channel = _channelFactory.Create(automaticRecoveryEnabled: true, requestedHeartbeat: 60);
 
                 basicProperties = basicProperties ?? new BasicProperties { DeliveryMode = 2, Persistent = true };
 

--- a/RabbitMQSimpleProducer/ProducerChannelPool.cs
+++ b/RabbitMQSimpleProducer/ProducerChannelPool.cs
@@ -1,19 +1,24 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text;
+using Newtonsoft.Json;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Framing;
 using RabbitMQSimpleConnectionFactory.Entity;
 using RabbitMQSimpleConnectionFactory.Library;
-using System.Text;
 
-namespace RabbitMQSimpleProducer {
-    public class ProducerChannelPool : IProducerChannelPool {
+namespace RabbitMQSimpleProducer
+{
+    public class ProducerChannelPool : IProducerChannelPool
+    {
 
         private readonly ConnectionPool _connectionPool;
-        public ProducerChannelPool(int poolSize, ConnectionSetting connectionSetting) {
-            _connectionPool = new ConnectionPool(poolSize, connectionSetting);
+        public ProducerChannelPool(int poolSize, ConnectionSetting connectionSetting, string clientProvidedName = null)
+        {
+
+            var channelFactory = new ChannelFactory(connectionSetting, clientProvidedName);
+            _connectionPool = new ConnectionPool(poolSize, channelFactory);
         }
 
-        public void Publish<T>(T obj, string exchange = null, string routingKey = null, IBasicProperties basicProperties = null) {
+        public void Publish<T>(T obj, string exchange = null, string routingKey = null, IBasicProperties basicProperties = null)
+        {
             var data = JsonConvert.SerializeObject(obj);
             var buffer = Encoding.UTF8.GetBytes(data);
             var channel = _connectionPool.GetChannel();

--- a/RabbitMQSimpleProducer/RabbitMQSimpleProducer.csproj
+++ b/RabbitMQSimpleProducer/RabbitMQSimpleProducer.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Alexandre Brandão Lustosa</Authors>
     <RepositoryUrl>https://github.com/alexandrebl/RabbitMQSimpleProducer</RepositoryUrl>
-    <Version>1.0.14</Version>
+    <Version>1.0.20</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
-    <PackageReference Include="RabbitMQSimpleConnectionFactory" Version="1.0.9" />
+    <PackageReference Include="RabbitMQSimpleConnectionFactory" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/RabbitMQSimpleProducer/RabbitMQSimpleProducer.csproj
+++ b/RabbitMQSimpleProducer/RabbitMQSimpleProducer.csproj
@@ -4,14 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Alexandre Brandão Lustosa</Authors>
     <RepositoryUrl>https://github.com/alexandrebl/RabbitMQSimpleProducer</RepositoryUrl>
-    <Version>1.0.20</Version>
+    <Version>2.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
-    <PackageReference Include="RabbitMQSimpleConnectionFactory" Version="2.0.0" />
+    <PackageReference Include="RabbitMQSimpleConnectionFactory" Version="2.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
O que:
- Atualiza a dependência RabbitMQSimpleConnection factory.
- Adiciona sobrecarga de construtor com parâmetro ChannelFactory.
- Desabilita auto recovery da sdk do RabbitMQ.
- Adiciona parâmetro opcional "clientProvidedName" no construtor da classe ProducerChannelPool.

Por que:
- Correções importantes foram feitas na RabbitMQSimpleConnectionFactory v2.1.0.
- Em algumas aplicações será necessário especificar um ChannelFactory específico para evitar criar multiplas conexões diferentes.
- Auto recovery para o produtor pode gerar vários tipos de problemas de desconexão.
- Parâmetro "clientProvidedName" permite identificar no RabbitMQ de onde vem uma conexão específica.